### PR TITLE
Package install for Ubuntu-based local development environment

### DIFF
--- a/local_development.yml
+++ b/local_development.yml
@@ -72,7 +72,7 @@
             repo: "{{ item.repo }}"
             filename: "{{ item.name }}"
             state: "present"
-          with_items:
+          loop:
             - { name: "terraform", repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main" }
             - { name: "kubectl", repo: "deb https://apt.kubernetes.io/ kubernetes-xenial main" }
             - { name: "google-cloud-sdk", repo: "deb https://packages.cloud.google.com/apt cloud-sdk main" }
@@ -102,7 +102,7 @@
             url: "{{ item.download_url }}"
             dest: "/usr/local/bin/{{ item.exe }}"
             mode: 0555
-          with_items: 
+          loop: 
             - { exe: "aws-iam-authenticator", download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" }
       tags: system
 

--- a/local_development.yml
+++ b/local_development.yml
@@ -81,6 +81,7 @@
 
     - name: Ensure availability of system commands
       when: ansible_distribution != "MacOSX"
+      tags: system
       block:
         - name: Install commands via package manager
           become: yes
@@ -94,17 +95,26 @@
               - azure-cli
             state: present
         
-        # TODO: Determine if aws-iam-authenticator already exists in path and skip below if it does
+        - name: Install commands via download 
+          block:
+            # Determine if the executable already exists in path
+            - name: Check if commands are already available
+              ansible.builtin.command:
+                cmd: "which {{ item.exe }}"
+              register: command_availability
+              ignore_errors: true
+              loop:
+                - { exe: "aws-iam-authenticator", download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" }
 
-        - name: Install commands via download (may take some time)
-          become: yes
-          ansible.builtin.get_url:
-            url: "{{ item.download_url }}"
-            dest: "/usr/local/bin/{{ item.exe }}"
-            mode: 0555
-          loop: 
-            - { exe: "aws-iam-authenticator", download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" }
-      tags: system
+            # If command found not to be available download and install
+            - name: Download and install any required commands (may take some time)
+              become: yes
+              ansible.builtin.get_url:
+                url: "{{ item.item.download_url }}"
+                dest: "/usr/local/bin/{{ item.item.exe }}"
+                mode: 0555
+              when: item.rc != 0
+              loop: "{{ command_availability.results }}"
 
     - name: Ensure availability of system commands (MacOSX)
       when: ansible_distribution == "MacOSX"

--- a/local_development.yml
+++ b/local_development.yml
@@ -52,18 +52,58 @@
         HOME: "{{ lookup('env','HOME') }}"
       tags: credentials
 
+    - name: Add pacakge keys and repositories for Ubuntu
+      when: ansible_distribution == "Ubuntu"
+      block:
+
+        - name: Add package keys
+          become: yes
+          ansible.builtin.apt_key:
+            url: "{{ item }}"
+            state: present
+          loop:
+            - https://apt.releases.hashicorp.com/gpg # for terraform
+            - https://packages.cloud.google.com/apt/doc/apt-key.gpg # for kubectl & google-cloud-sdk
+            - https://packages.microsoft.com/keys/microsoft.asc # for azure-cli
+        
+        - name: Add package repositories
+          become: yes
+          ansible.builtin.apt_repository:
+            repo: "{{ item.repo }}"
+            filename: "{{ item.name }}"
+            state: "present"
+          with_items:
+            - { name: "terraform", repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main" }
+            - { name: "kubectl", repo: "deb https://apt.kubernetes.io/ kubernetes-xenial main" }
+            - { name: "google-cloud-sdk", repo: "deb https://packages.cloud.google.com/apt cloud-sdk main" }
+            - { name: "azure-cli", repo: "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ {{ ansible_distribution_release }} main" }
+      tags: system
+
     - name: Ensure availability of system commands
       when: ansible_distribution != "MacOSX"
-      ansible.builtin.package:
-        name:
-          - pip
-          - git
-          - terraform
-          - kubectl
-          - aws-iam-authenticator
-          - google-cloud-sdk
-          - azure-cli
-        state: present
+      block:
+        - name: Install commands via package manager
+          become: yes
+          ansible.builtin.package:
+            name:
+              - pip
+              - git
+              - terraform
+              - kubectl
+              - google-cloud-sdk
+              - azure-cli
+            state: present
+        
+        # TODO: Determine if aws-iam-authenticator already exists in path and skip below if it does
+
+        - name: Install commands via download (may take some time)
+          become: yes
+          ansible.builtin.get_url:
+            url: "{{ item.download_url }}"
+            dest: "/usr/local/bin/{{ item.exe }}"
+            mode: 0555
+          with_items: 
+            - { exe: "aws-iam-authenticator", download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" }
       tags: system
 
     - name: Ensure availability of system commands (MacOSX)


### PR DESCRIPTION
Hey @wmudge 

Added tasks to install required packages for local dev environment on Ubuntu.

The biggest change is that, because we are interacting with APT repos and package manager, I've added to add `become: yes` to some of the Ubuntu specific tasks.
Playbook execution in this case becomes:
```
ansible-playbook local_development.yml --ask-become-pass
```

Signed-off-by: Jim Enright <jenright@cloudera.com>